### PR TITLE
Compute loss chance and stop the timer when all the slots are filled

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -242,9 +242,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 65cd42c3101a71045b810d1f30d3b749, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_furnitureSlotPrefab: {fileID: 1988203463035253636, guid: 9e0d57ec0ea0dfa4a9acc08aaedf0502, type: 3}
+  m_goFurnitureSlotPrefab: {fileID: 1988203463035253636, guid: 9e0d57ec0ea0dfa4a9acc08aaedf0502, type: 3}
   m_furnitureSlotLayoutGroup: {fileID: 271312454}
-  m_draggableFurniturePrefab: {fileID: 4775905344252296661, guid: 056fe3c4d236e794d943e84707d03e8b, type: 3}
+  m_goDraggableFurniturePrefab: {fileID: 4775905344252296661, guid: 056fe3c4d236e794d943e84707d03e8b, type: 3}
   m_draggableFurnitureLayoutGroup: {fileID: 870254024}
 --- !u!1 &271312450
 GameObject:

--- a/Assets/Scripts/Interactable/DraggableFurnitureBehaviour.cs
+++ b/Assets/Scripts/Interactable/DraggableFurnitureBehaviour.cs
@@ -19,16 +19,16 @@ namespace FFF.Behaviours.Interactable
          get => m_data;
       }
 
-      private int m_stability;
+      private int m_dStability;
 
       public int Stability
       {
-         get => m_stability;
+         get => m_dStability;
          set
          {
-            m_stability = value;
+            m_dStability = value;
 
-            m_stabilityDisplay.text = m_stability.ToString();
+            m_stabilityDisplay.text = m_dStability.ToString();
          }
       }
 

--- a/Assets/Scripts/Managers/LevelManager.cs
+++ b/Assets/Scripts/Managers/LevelManager.cs
@@ -24,6 +24,14 @@ namespace FFF.Managers
 
       #endregion
 
+      #region Checking result
+
+      private int m_dFurnitureCount;
+
+      public bool IsCheckingResult => m_dFurnitureCount == m_lstStackedFurniture.Count;
+
+      #endregion
+
       #region Drag n drop management
 
       private DashedLineBorderBehaviour m_lastSelectedInteractable;
@@ -69,6 +77,18 @@ namespace FFF.Managers
                }
 
                m_dCurrentRefillableSlotId += 1;
+
+               if(IsCheckingResult)
+               {
+                  List<FurnitureDropSlotBehaviour> l_lstAllStackedFurniture = new List<FurnitureDropSlotBehaviour>();
+
+                  foreach(FurnitureDropSlotBehaviour l_furniture in m_lstStackedFurniture)
+                  {
+                     l_lstAllStackedFurniture.Add(l_furniture);
+                  }
+
+                  FurnitureUtils.TryClimbing(m_cat, l_lstAllStackedFurniture);
+               }
             }
             else
             {
@@ -97,7 +117,9 @@ namespace FFF.Managers
       {
          ScriptableFurnitureData[] l_lstFurniture = PlayerSaveSingleton.Instance.CurentLevelData;
 
-         for (int l_i = 0; l_i < l_lstFurniture.Length; l_i++)
+         m_dFurnitureCount = l_lstFurniture.Length;
+
+         for (int l_i = 0; l_i < m_dFurnitureCount; l_i++)
          {
             GameObject l_goSlot = Instantiate(m_goFurnitureSlotPrefab, m_furnitureSlotLayoutGroup.transform);
             l_goSlot.GetComponent<FurnitureDropSlotBehaviour>().Init(this);

--- a/Assets/Scripts/Managers/LevelManager.cs
+++ b/Assets/Scripts/Managers/LevelManager.cs
@@ -14,11 +14,11 @@ namespace FFF.Managers
    {
       #region Level creation
 
-      [SerializeField] private GameObject m_furnitureSlotPrefab;
+      [SerializeField] private GameObject m_goFurnitureSlotPrefab;
 
       [SerializeField] private VerticalLayoutGroup m_furnitureSlotLayoutGroup;
 
-      [SerializeField] private GameObject m_draggableFurniturePrefab;
+      [SerializeField] private GameObject m_goDraggableFurniturePrefab;
 
       [SerializeField] private HorizontalLayoutGroup m_draggableFurnitureLayoutGroup;
 
@@ -99,11 +99,11 @@ namespace FFF.Managers
 
          for (int l_i = 0; l_i < l_lstFurniture.Length; l_i++)
          {
-            GameObject l_goSlot = Instantiate(m_furnitureSlotPrefab, m_furnitureSlotLayoutGroup.transform);
+            GameObject l_goSlot = Instantiate(m_goFurnitureSlotPrefab, m_furnitureSlotLayoutGroup.transform);
             l_goSlot.GetComponent<FurnitureDropSlotBehaviour>().Init(this);
 
 
-            GameObject l_goDraggable = Instantiate(m_draggableFurniturePrefab, m_draggableFurnitureLayoutGroup.transform);
+            GameObject l_goDraggable = Instantiate(m_goDraggableFurniturePrefab, m_draggableFurnitureLayoutGroup.transform);
             l_goDraggable.GetComponent<DraggableFurnitureBehaviour>().Init(l_lstFurniture[l_i], this);
          }
 

--- a/Assets/Scripts/UI/DashedLineBorderBehaviour.cs
+++ b/Assets/Scripts/UI/DashedLineBorderBehaviour.cs
@@ -41,8 +41,8 @@ namespace FFF.Behaviours.UI
 
       private Gradient m_selectionGradient;
 
-      private float m_gradientTimer;
-      private int m_timerCoef;
+      private float m_fGradientTimer;
+      private int m_dTimerCoef;
 
       #endregion
 
@@ -60,9 +60,9 @@ namespace FFF.Behaviours.UI
          m_selectionGradient = new Gradient();
          m_selectionGradient.SetKeys(l_lstColor, l_lstAlpha);
 
-         m_gradientTimer = 0;
+         m_fGradientTimer = 0;
 
-         m_timerCoef = 1;
+         m_dTimerCoef = 1;
 
          m_button = GetComponent<Button>();
 
@@ -100,16 +100,16 @@ namespace FFF.Behaviours.UI
       {
          if(m_isWaitingSelection == true)
          {
-            if (m_gradientTimer > 1 || m_gradientTimer < 0)
+            if (m_fGradientTimer > 1 || m_fGradientTimer < 0)
             {
-               m_timerCoef *= -1;
+               m_dTimerCoef *= -1;
             }
 
-            Color l_newColor = m_selectionGradient.Evaluate(m_gradientTimer);
+            Color l_newColor = m_selectionGradient.Evaluate(m_fGradientTimer);
 
             m_border.material.SetColor("_MainColor", l_newColor);
 
-            m_gradientTimer += 0.005f * m_timerCoef;
+            m_fGradientTimer += 0.005f * m_dTimerCoef;
          }
       }
 

--- a/Assets/Scripts/UI/FurnitureDropSlotBehaviour.cs
+++ b/Assets/Scripts/UI/FurnitureDropSlotBehaviour.cs
@@ -20,14 +20,14 @@ namespace FFF.Behaviours.UI
          }
       }
 
-      private int m_currentStability;
+      private int m_dCurrentStability;
 
       public int CurrentStability
       {
-         get => m_currentStability;
+         get => m_dCurrentStability;
          set
          {
-            m_currentStability = value;
+            m_dCurrentStability = value;
          }
       }
 

--- a/Assets/Scripts/UI/TimerBehaviour.cs
+++ b/Assets/Scripts/UI/TimerBehaviour.cs
@@ -1,3 +1,4 @@
+using FFF.Managers;
 using FFF.Player;
 using FFF.Utils;
 using TMPro;
@@ -11,16 +12,20 @@ namespace FFF.Behaviours.UI
 
       private float m_fTime;
 
+      private LevelManager m_levelManager;
+
       private void Start()
       {
          m_timerDisplay = GetComponentInChildren<TextMeshProUGUI>();
 
          m_fTime = PlayerSaveSingleton.Instance.TimerMax * 60f;
+
+         m_levelManager = GetComponentInParent<LevelManager>();
       }
 
       private void Update()
       {
-         if (PlayerStateSingleton.Instance.GameScreen == EGameScreen.GAME_SCREEN)
+         if (PlayerStateSingleton.Instance.GameScreen == EGameScreen.GAME_SCREEN && !m_levelManager.IsCheckingResult)
          {
             m_fTime -= Time.deltaTime;
 

--- a/Assets/Scripts/UI/TimerBehaviour.cs
+++ b/Assets/Scripts/UI/TimerBehaviour.cs
@@ -9,24 +9,24 @@ namespace FFF.Behaviours.UI
    {
       private TextMeshProUGUI m_timerDisplay;
 
-      private float m_time;
+      private float m_fTime;
 
       private void Start()
       {
          m_timerDisplay = GetComponentInChildren<TextMeshProUGUI>();
 
-         m_time = PlayerSaveSingleton.Instance.TimerMax * 60f;
+         m_fTime = PlayerSaveSingleton.Instance.TimerMax * 60f;
       }
 
       private void Update()
       {
          if (PlayerStateSingleton.Instance.GameScreen == EGameScreen.GAME_SCREEN)
          {
-            m_time -= Time.deltaTime;
+            m_fTime -= Time.deltaTime;
 
-            if (m_time <= 0)
+            if (m_fTime <= 0)
             {
-               m_time = 0;
+               m_fTime = 0;
 
                PlayerStateSingleton.Instance.GameScreen = EGameScreen.END_SCREEN;
             }
@@ -37,12 +37,12 @@ namespace FFF.Behaviours.UI
 
       private void UpdateDisplay()
       {
-         m_timerDisplay.text = string.Format("{0:0}:{1:00}", Mathf.FloorToInt(m_time / 60f), Mathf.FloorToInt(m_time % 60f));
+         m_timerDisplay.text = string.Format("{0:0}:{1:00}", Mathf.FloorToInt(m_fTime / 60f), Mathf.FloorToInt(m_fTime % 60f));
       }
 
       public void Reset()
       {
-         m_time = PlayerSaveSingleton.Instance.TimerMax * 60f;
+         m_fTime = PlayerSaveSingleton.Instance.TimerMax * 60f;
       }
    }
 }


### PR DESCRIPTION
Closes #3

**Changes:**
- Refactoring: Applying naming convention
- Make the timer to stop when the result is computed
- Make the result to be computed if the player filled all furniture slots