### PR TITLE
Make furnitures to not leave slots scope

### DIFF
--- a/Assets/Resources/Prefabs/Interactable/DraggableFurniture.prefab
+++ b/Assets/Resources/Prefabs/Interactable/DraggableFurniture.prefab
@@ -92,6 +92,8 @@ GameObject:
   - component: {fileID: 1363370773714004638}
   - component: {fileID: 6067231645447763552}
   - component: {fileID: 2215497147280736324}
+  - component: {fileID: 4906097654777357192}
+  - component: {fileID: -6698173553324945809}
   m_Layer: 5
   m_Name: DraggableFurniture
   m_TagString: Untagged
@@ -117,7 +119,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 750, y: 750}
+  m_SizeDelta: {x: 750, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &5889130128569276881
 CanvasRenderer:
@@ -341,6 +343,40 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!114 &4906097654777357192
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4775905344252296661}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 1
+  m_AspectRatio: 1
+--- !u!114 &-6698173553324945809
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4775905344252296661}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &7181097130451297275
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Prefabs/Interactable/FurnitureSlot.prefab
+++ b/Assets/Resources/Prefabs/Interactable/FurnitureSlot.prefab
@@ -14,6 +14,7 @@ GameObject:
   - component: {fileID: 7755145684546524045}
   - component: {fileID: 8080885317289385219}
   - component: {fileID: 7647372660340407919}
+  - component: {fileID: 6056332851602838357}
   m_Layer: 5
   m_Name: FurnitureSlot
   m_TagString: Untagged
@@ -39,7 +40,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 750, y: 750}
+  m_SizeDelta: {x: 0, y: 750}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &3092571861218309554
 CanvasRenderer:
@@ -251,6 +252,20 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!114 &6056332851602838357
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1988203463035253636}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 86710e43de46f6f4bac7c8e50813a599, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_AspectMode: 2
+  m_AspectRatio: 1
 --- !u!1 &4789583738098843042
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -1176,9 +1176,9 @@ MonoBehaviour:
   m_ChildAlignment: 7
   m_Spacing: 0
   m_ChildForceExpandWidth: 0
-  m_ChildForceExpandHeight: 0
+  m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 0
-  m_ChildControlHeight: 0
+  m_ChildControlHeight: 1
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 1

--- a/Assets/Scripts/Managers/LevelManager.cs
+++ b/Assets/Scripts/Managers/LevelManager.cs
@@ -169,6 +169,11 @@ namespace FFF.Managers
 
          m_dFurnitureCount = l_lstFurniture.Length;
 
+
+         HorizontalLayoutGroup l_horizontalLayoutGroup = m_draggableFurnitureLayoutGroup.GetComponent<HorizontalLayoutGroup>();
+         l_horizontalLayoutGroup.childControlWidth = true;
+         l_horizontalLayoutGroup.childForceExpandWidth = true;
+
          for (int l_i = 0; l_i < m_dFurnitureCount; l_i++)
          {
             GameObject l_goSlot = Instantiate(m_goFurnitureSlotPrefab, m_furnitureSlotLayoutGroup.transform);
@@ -178,6 +183,9 @@ namespace FFF.Managers
             GameObject l_goDraggable = Instantiate(m_goDraggableFurniturePrefab, m_draggableFurnitureLayoutGroup.transform);
             l_goDraggable.GetComponent<DraggableFurnitureBehaviour>().Init(l_lstFurniture[l_i], this);
          }
+
+         l_horizontalLayoutGroup.childControlWidth = false;
+         l_horizontalLayoutGroup.childForceExpandWidth = false;
 
          m_cat = GetComponentInChildren<CatBehaviour>();
          m_cat.Init(l_lstFurniture.Length);

--- a/Assets/Scripts/UI/DashedLineBorderBehaviour.cs
+++ b/Assets/Scripts/UI/DashedLineBorderBehaviour.cs
@@ -54,8 +54,6 @@ namespace FFF.Behaviours.UI
 
       public virtual void Init(LevelManager p_manager)
       {
-         DrawBorder();
-
          GradientAlphaKey[] l_lstAlpha = new GradientAlphaKey[] { new GradientAlphaKey(1, 0)};
 
          GradientColorKey[] l_lstColor = new GradientColorKey[] { 
@@ -125,6 +123,12 @@ namespace FFF.Behaviours.UI
          {
             m_levelManager.LastSelectedInteractable = this;
          }
+      }
+
+      public void OnRectTransformDimensionsChange()
+      {
+         DrawBorder();
+
       }
    }
 }


### PR DESCRIPTION
Closes #30 

**Changes:**
- Make layout groups to control furniture sizes
- Make furniture slot borders to be drawn after each rect transform update